### PR TITLE
Fix readme code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Current implemented(&radic;) and planned(&times;) algorithms:
 #####Implements Vertex interface of this package if you want to use AddVertexWithEdges(optional):
 ```go
 type Vertex interface {
-	Id() Id
+	ID() ID
 	Edges() []Edge
 }
 
 type Edge interface {
-	Get() (from Id, to Id, weight float64)
+	Get() (from ID, to ID, weight float64)
 }
 ```
 ## Supported Operations
@@ -104,7 +104,7 @@ type myEdge struct {
 	weight float64
 }
 
-func (vertex *myVertex) Id() goraph.Id {
+func (vertex *myVertex) ID() goraph.ID {
 	return vertex.id
 }
 
@@ -122,7 +122,7 @@ func (vertex *myVertex) Edges() (edges []goraph.Edge) {
 	return
 }
 
-func (edge *myEdge) Get() (goraph.Id, goraph.Id, float64) {
+func (edge *myEdge) Get() (goraph.ID, goraph.ID, float64) {
 	return edge.from, edge.to, edge.weight
 }
 


### PR DESCRIPTION
Fix these errors:
```
$ go run main.go
# command-line-arguments
./main.go:20:30: undefined: goraph.Id
./main.go:38:28: undefined: goraph.Id
./main.go:66:89: cannot use &myVertex literal (type *myVertex) as type goraph.Vertex in argument to graph.AddVertexWithEdges:
  *myVertex does not implement goraph.Vertex (missing ID method)
    have Id() <T>
    want ID() goraph.ID
./main.go:67:115: cannot use &myVertex literal (type *myVertex) as type goraph.Vertex in argument to graph.AddVertexWithEdges:
  *myVertex does not implement goraph.Vertex (missing ID method)
    have Id() <T>
    want ID() goraph.ID
./main.go:68:115: cannot use &myVertex literal (type *myVertex) as type goraph.Vertex in argument to graph.AddVertexWithEdges:
  *myVertex does not implement goraph.Vertex (missing ID method)
    have Id() <T>
    want ID() goraph.ID
./main.go:69:97: cannot use &myVertex literal (type *myVertex) as type goraph.Vertex in argument to graph.AddVertexWithEdges:
  *myVertex does not implement goraph.Vertex (missing ID method)
    have Id() <T>
    want ID() goraph.ID
./main.go:70:124: cannot use &myVertex literal (type *myVertex) as type goraph.Vertex in argument to graph.AddVertexWithEdges:
  *myVertex does not implement goraph.Vertex (missing ID method)
    have Id() <T>
    want ID() goraph.ID
./main.go:71:123: cannot use &myVertex literal (type *myVertex) as type goraph.Vertex in argument to graph.AddVertexWithEdges:
  *myVertex does not implement goraph.Vertex (missing ID method)
    have Id() <T>
    want ID() goraph.ID
./main.go:72:105: cannot use &myVertex literal (type *myVertex) as type goraph.Vertex in argument to graph.AddVertexWithEdges:
  *myVertex does not implement goraph.Vertex (missing ID method)
    have Id() <T>
    want ID() goraph.ID
./main.go:73:115: cannot use &myVertex literal (type *myVertex) as type goraph.Vertex in argument to graph.AddVertexWithEdges:
  *myVertex does not implement goraph.Vertex (missing ID method)
    have Id() <T>
    want ID() goraph.ID
./main.go:73:115: too many errors
```